### PR TITLE
Add option to remove JourneyMap mod F3 Lines

### DIFF
--- a/src/main/java/de/tyrannus/cleandebug/CleanDebug.java
+++ b/src/main/java/de/tyrannus/cleandebug/CleanDebug.java
@@ -52,6 +52,10 @@ public class CleanDebug implements ClientModInitializer {
         if (CleanDebugConfig.hideNoiseRouter) {
             lines.removeIf(s -> s.startsWith("NoiseRouter"));
         }
+
+        if (CleanDebugConfig.hideJourneyMap) {
+            lines.removeIf(s -> s.startsWith("§b[JM]"));
+        }
     }
 
     public static void modifyRightLines(List<String> lines) {

--- a/src/main/java/de/tyrannus/cleandebug/CleanDebugConfig.java
+++ b/src/main/java/de/tyrannus/cleandebug/CleanDebugConfig.java
@@ -54,4 +54,7 @@ public class CleanDebugConfig extends MidnightConfig {
 
     @Entry
     public static boolean hideModernFix = true;
+
+    @Entry
+    public static boolean hideJourneyMap = true;
 }

--- a/src/main/resources/assets/clean-debug/lang/de_de.json
+++ b/src/main/resources/assets/clean-debug/lang/de_de.json
@@ -30,6 +30,7 @@
   "clean-debug.midnightconfig.hidePresenceFootsteps": "Verstecke Presence Footsteps Debuginfos",
   "clean-debug.midnightconfig.hideDistantHorizons": "Verstecke Distant Horizons Debuginfos",
   "clean-debug.midnightconfig.hideModernFix": "Verstecke ModernFix Debuginfos",
+  "clean-debug.midnightconfig.hideJourneyMap": "Verstecke JourneyMap Debuginfos",
 
   "modmenu.descriptionTranslation.clean-debug": "Entfernt nutzlose Informationen aus dem Debugbildschirm.",
   "modmenu.summaryTranslation.clean-debug": "Erlaubt das Individualisieren des F3-Bildschirms."

--- a/src/main/resources/assets/clean-debug/lang/en_us.json
+++ b/src/main/resources/assets/clean-debug/lang/en_us.json
@@ -30,6 +30,7 @@
   "clean-debug.midnightconfig.hidePresenceFootsteps": "Hide Presence Footstep's debug info",
   "clean-debug.midnightconfig.hideDistantHorizons": "Hide Distant Horizons' debug info",
   "clean-debug.midnightconfig.hideModernFix": "Hide ModernFix's debug info",
+  "clean-debug.midnightconfig.hideJourneyMap": "Hide JourneyMap's debug info",
 
   "modmenu.descriptionTranslation.clean-debug": "Removes useless information from the debug screen.",
   "modmenu.summaryTranslation.clean-debug": "Allows you to customize what you see on the F3 screen."

--- a/src/main/resources/assets/clean-debug/lang/fr_fr.json
+++ b/src/main/resources/assets/clean-debug/lang/fr_fr.json
@@ -30,6 +30,7 @@
   "clean-debug.midnightconfig.hidePresenceFootsteps": "Cache Hide Presence Footstep's debug info",
   "clean-debug.midnightconfig.hideDistantHorizons": "Cache les infos de débogage de Distant Horizons.",
   "clean-debug.midnightconfig.hideModernFix": "Cache les infos de débogage de ModernFix",
+  "clean-debug.midnightconfig.hideJourneyMap": "Cache les infos de débogage de JourneyMap",
 
   "modmenu.descriptionTranslation.clean-debug": "Enlève les informations inutiles de l’écran de débogage.",
   "modmenu.summaryTranslation.clean-debug": "Permet de customiser ce que vous voulez voir sur le menu F3."


### PR DESCRIPTION
Updated CleanDebug.Java & CleanDebugConfig.java to filter JourneyMap's F3 lines, also edited the German, English and French language files for mod menu wording, chinese language file not updated as I was not sure of the correct spelling.