### PR TITLE
Cave Dust support

### DIFF
--- a/src/main/java/de/tyrannus/cleandebug/CleanDebug.java
+++ b/src/main/java/de/tyrannus/cleandebug/CleanDebug.java
@@ -137,6 +137,10 @@ public class CleanDebug implements ClientModInitializer {
             }
         }
 
+        if (CleanDebugConfig.hideCaveDust) {
+            text.removeIf(s -> s.startsWith("Particle amount evaluated: "));
+        }
+
         while (!text.isEmpty() && text.get(0).isEmpty()) {
             text.remove(0);
         }

--- a/src/main/java/de/tyrannus/cleandebug/CleanDebugConfig.java
+++ b/src/main/java/de/tyrannus/cleandebug/CleanDebugConfig.java
@@ -66,4 +66,7 @@ public class CleanDebugConfig extends MidnightConfig {
 
     @Entry
     public static boolean hideDynamicFps = true;
+
+    @Entry
+    public static boolean hideCaveDust = true;
 }

--- a/src/main/resources/assets/clean-debug/lang/en_us.json
+++ b/src/main/resources/assets/clean-debug/lang/en_us.json
@@ -36,6 +36,7 @@
   "clean-debug.midnightconfig.hideLambDynamicLights": "Hide LambDynamicLights' debug info",
   "clean-debug.midnightconfig.hideDynamicFps": "Hide DynamicFps' debug info",
   "clean-debug.midnightconfig.hideDynamicFps.tooltip": "DynamicFps adds debug info only while the game is unfocused.",
+  "clean-debug.midnightconfig.hideCaveDust": "Hide Cave Dust's debug info",
 
   "modmenu.descriptionTranslation.clean-debug": "Removes useless information from the debug screen.",
   "modmenu.summaryTranslation.clean-debug": "Allows you to customize what you see on the F3 screen."


### PR DESCRIPTION
[Cave Dust](https://modrinth.com/mod/cave-dust) for 1.21 adds a "Particle amount evaluated: " debug line that cannot be disabled through the mod config. This PR adds the option to do so in CleanF3.